### PR TITLE
Rephrasing FLOSS mentioning

### DIFF
--- a/doc/1.manual/x1.htm
+++ b/doc/1.manual/x1.htm
@@ -94,13 +94,11 @@ by choosing menu <b>Help/Browser</b> and looking in
 "Pure Data/5.reference".
 
 <P>
-The "example" patches are also available from Pd's browser. They appear in subdirectories 
-named "2.control.examples", "3.audio.examples" and "4.data.structures". Some additional 
-patches in "7.stuff" might also be helpful.
+The "example" patches are also available from Pd's browser</b>.  
+Some additional patches in "7.stuff" might also be helpful.
 
 <P>
-To get started writing your own C extensions, refer to "6.externs". For more about externals, 
-please refer to <A href=x4.htm>chapter 4 </A>of this manual.
+To get started writing your own C extensions, refer to <A href=x4.htm>chapter 4 </A>of this manual.
 
 <H3> <A id=s2> 1.2. other resources </A> </H3>
 
@@ -108,14 +106,12 @@ please refer to <A href=x4.htm>chapter 4 </A>of this manual.
 <a href="http://www.pure-data.info/"> pure-data.info</a>, which aims to be the
 central resource for Pd, from documentation and
 downloads; to forums, member pages, and a patch exchange.
-You can check <A href=http://puredata.info/docs/BooksAboutPd/>
-puredata.info/docs/BooksAboutPd/</A>.
-
-<P> More documentation (warning: very outdated specially on "how to install Pd") is available on the Pd FLOSS site:
-<A href=https://en.flossmanuals.net/pure-data/_full/>
-en.flossmanuals.net/pure-data/_full/</A> (English) and
-<A href=http://fr.flossmanuals.net/PureData/>
-fr.flossmanuals.net/PureData/</A> (French).
+	
+<P>You can check <A href=http://puredata.info/docs/BooksAboutPd/>
+puredata.info/docs/BooksAboutPd/</A> for more documentation. But please 
+be aware that some references might be very old and outdated. For instance, 
+the FLOSS Manuals deal with installing Pd Extended, which is now an abandoned
+fork of Pd since 2013! Please refer to this manual for more up to date information.
 
 <P>
 Most of the interesting news related to Pd shows up on the Pd mailing list,
@@ -129,15 +125,12 @@ best source of recent information regarding installation problems and bugs.  It
 is perfectly reasonable to post "beginner" questions on this list; alternatively
 you can contact msp@ucsd.edu for help.
 
-<P> Many extensions to Pd are announced on the mailing list. In particular,
+<P> Many extensions to Pd are announced on the mailing list.  In particular,
 for people interested in graphics, there is a 3D graphics rendering package,
 named GEM, based on OpenGL, written by Mark Danks, adapted to Linux by
 Guenter Geiger, and now maintained by IOhannes zm&ouml;lnig. You can get
-it from: <A href="http://gem.iem.at/">http://gem.iem.at/</A>, via "Find externals" in the
-'Help Menu' or package manager of your Linux distribution. Another option is Ofelia, a Pd external
-that allows you to use openFrameworks and Lua within Pd for creating audiovisual artwork 
-or multimedia applications such as games. Get it also via via "Find externals" or from 
-<A href="https://github.com/cuinjune/Ofelia">https://github.com/cuinjune/Ofelia</A>.
+it from: <A href="http://gem.iem.at/">http://gem.iem.at/</A>, via "Find externals"
+or package manager of your Linux distribution.
 
 <P>
 <BR><BR>


### PR DESCRIPTION
Making a realistic and more productive mentioning of FLOSS Manuals when referring to 'Books about Pd'.